### PR TITLE
Add other-modules to tests test-suite

### DIFF
--- a/twitter-feed.cabal
+++ b/twitter-feed.cabal
@@ -45,3 +45,5 @@ test-suite twitter-library
 
   default-language:    Haskell2010
   ghc-options:         -Wall
+  other-modules:
+    Web.Twitter.Feed.Tests


### PR DESCRIPTION
The tests test-suite didn't have a other-modules field, which means that the tar.gz in Hackage doesn't have all required files. See #12.