### PR TITLE
Move to new travis ci infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,18 @@
 language: haskell
 
-env:
-  matrix:
-    - GHC_VERSION=7.6.3  CABAL_VERSION=1.20
-    - GHC_VERSION=7.8.4  CABAL_VERSION=1.20
-    - GHC_VERSION=7.10.1 CABAL_VERSION=1.22
+sudo: false
+
+matrix:
+  include:
+    - env: CABALVER=1.20 GHCVER=7.6.3
+      addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.3], sources: [hvr-ghc]}}
+    - env: CABALVER=1.20 GHCVER=7.8.4
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}
+    - env: CABALVER=1.22 GHCVER=7.10.1
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.1], sources: [hvr-ghc]}}
 
 before_install:
-  - sudo apt-add-repository -y ppa:hvr/ghc
-  - sudo apt-get update
-  - sudo apt-get install -y ghc-$GHC_VERSION cabal-install-$CABAL_VERSION
-  - export PATH=/opt/ghc/$GHC_VERSION/bin:/opt/cabal/$CABAL_VERSION/bin:$PATH
+  - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
 
 install:
   - cabal update


### PR DESCRIPTION
@jsl @jpvillaisaza @jsantos17 any comments?
I noticed that travis was showing a warning about legacy infrastructure and the new container-based infrastructure. [Here](http://docs.travis-ci.com/user/migrating-from-legacy/) more information... and i noticed that other repos are starting to move on... like [pandoc](https://github.com/jgm/pandoc/pull/2110)