### PR TITLE
Change upper bound of http-conduit

### DIFF
--- a/twitter-feed.cabal
+++ b/twitter-feed.cabal
@@ -1,5 +1,5 @@
 name:                twitter-feed
-version:             0.2.0.0
+version:             0.2.0.1
 synopsis:            Client for fetching Twitter timeline via Oauth
 description:         Fetches a user timeline from Twitter, and optionally linkifies the results using the Twitter entity API.
 homepage:            https://github.com/stackbuilders/twitter-feed

--- a/twitter-feed.cabal
+++ b/twitter-feed.cabal
@@ -25,7 +25,7 @@ library
     base               >= 4.6   && < 4.9,
     aeson              >= 0.8   && < 0.9,
     authenticate-oauth >= 1.5   && < 1.6,
-    http-conduit       >= 2.1.4 && < 2.1.6,
+    http-conduit       >= 2.1.4 && < 2.2.0,
     bytestring         >= 0.10  && < 0.11
 
   hs-source-dirs:      src


### PR DESCRIPTION
See #15. The library builds with http-conduit 2.1.6, which is the latest version (but not the one in Stackage right now). This pull requests also bumps the version to 0.2.0.1 for uploading after merging.