### PR TITLE
Loose aeson contraint to <0.10 and -j2 for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,9 @@ before_install:
 install:
   - cabal update
   - cabal sandbox init
-  - cabal install --only-dependencies --enable-tests
+  - cabal install --only-dependencies --enable-tests -j2
 
 script:
   - cabal configure --enable-tests
-  - cabal build
+  - cabal build -j2
   - cabal test

--- a/twitter-feed.cabal
+++ b/twitter-feed.cabal
@@ -23,7 +23,7 @@ library
 
   build-depends:
     base               >= 4.6   && < 4.9,
-    aeson              >= 0.8   && < 0.9,
+    aeson              >= 0.8   && < 0.10,
     authenticate-oauth >= 1.5   && < 1.6,
     http-conduit       >= 2.1.4 && < 2.2.0,
     bytestring         >= 0.10  && < 0.11


### PR DESCRIPTION
@jpvillaisaza @jsl could you check it please? this resolves #18 and since new documentation for travis tells us that we have 2 dedicated cores for the container, i added -j2