### PR TITLE
Update lts to 5.2. Add stack-work to .gitignore. Allow aeson-0.11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ cabal.config
 *.prof
 *.aux
 *.hp
+.stack-work/

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-3.5
+resolver: lts-5.2

--- a/twitter-feed.cabal
+++ b/twitter-feed.cabal
@@ -23,7 +23,7 @@ library
 
   build-depends:
     base               >= 4.6   && < 4.9,
-    aeson              >= 0.8   && < 0.11,
+    aeson              >= 0.8   && < 0.12,
     authenticate-oauth >= 1.5   && < 1.6,
     http-conduit       >= 2.1.4 && < 2.2.0,
     bytestring         >= 0.10  && < 0.11


### PR DESCRIPTION
First, I updated lts haskell resolver to 5.2. Then, I updated `aeson` dependency to allow `aeson 0.11`. Finally, I added `.stack-work/` to `.gitignore`.