### PR TITLE
Allow aeson 1.0

### DIFF
--- a/twitter-feed.cabal
+++ b/twitter-feed.cabal
@@ -23,7 +23,7 @@ library
 
   build-depends:
     base               >= 4.6   && < 4.10,
-    aeson              >= 0.8   && < 0.12,
+    aeson              >= 0.8   && < 1.1,
     authenticate-oauth >= 1.5   && < 1.7,
     http-conduit       >= 2.1.4 && < 2.2.0,
     bytestring         >= 0.10  && < 0.11


### PR DESCRIPTION
Changed build dependencies in Cabal to allow aeson 1.0.
I ran the tests an the resolver seems to be OK with the changes.