### PR TITLE
pack is needed in the readme oauth example

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,17 +15,18 @@ You must pass your OAuth credentials to the client. Create them as follows:
 
 ```haskell
 import Web.Authenticate.OAuth
+import Data.ByteString.Char8
 
 myoauth :: OAuth
 myoauth = newOAuth
     { oauthServerName     = "api.twitter.com"
-    , oauthConsumerKey    = "your consumer key"
-    , oauthConsumerSecret = "your consumer secret"
+    , oauthConsumerKey    = pack "your consumer key"
+    , oauthConsumerSecret = pack "your consumer secret"
     }
 
 mycred :: Credential
-mycred = newCredential "your oauth token"
-                       "your oauth token secret"
+mycred = newCredential (pack "your oauth token")
+                       (pack "your oauth token secret")
 ```
 
 Next, you can call the `timeline` function directly. The arguments to the


### PR DESCRIPTION
If one applies the example as it is now from the readme, there is an error saying 

```
<interactive>:19:29: error:
    * Couldn't match expected type `Data.ByteString.Internal.ByteString'
                  with actual type `[Char]'
    * In the `oauthConsumerKey' field of a record
      In the expression:
        newOAuth
          {oauthServerName = "api.twitter.com",
           oauthConsumerKey = "your consumer key",
           oauthConsumerSecret = "your consumer secret"}
      In an equation for `myoauth':
          myoauth
            = newOAuth
                {oauthServerName = "api.twitter.com",
                 oauthConsumerKey = "your consumer key",
                 oauthConsumerSecret = "your consumer secret"}

<interactive>:20:29: error:
    * Couldn't match expected type `Data.ByteString.Internal.ByteString'
                  with actual type `[Char]'
    * In the `oauthConsumerSecret' field of a record
      In the expression:
        newOAuth
          {oauthServerName = "api.twitter.com",
           oauthConsumerKey = "your consumer key",
           oauthConsumerSecret = "your consumer secret"}
      In an equation for `myoauth':
          myoauth
            = newOAuth
                {oauthServerName = "api.twitter.com",
                 oauthConsumerKey = "your consumer key",
                 oauthConsumerSecret = "your consumer secret"}
```

The solution is using `pack` as suggested in the [answer](https://stackoverflow.com/a/34399232)